### PR TITLE
Fix excel export with empty title

### DIFF
--- a/src/DataTable.vue
+++ b/src/DataTable.vue
@@ -169,11 +169,12 @@
 				const mimeType = 'data:application/vnd.ms-excel';
 				const html = this.renderTable().replace(/ /g, '%20');
 
+				const documentPrefix = this.title != '' ? this.title.replace(/ /g, '-') : 'Sheet'
 				const d = new Date();
 
 				var dummy = document.createElement('a');
 				dummy.href = mimeType + ', ' + html;
-				dummy.download = this.title.toLowerCase().replace(/ /g, '-') 
+				dummy.download = documentPrefix
 					+ '-' + d.getFullYear() + '-' + (d.getMonth()+1) + '-' + d.getDate()
 					+ '-' + d.getHours() + '-' + d.getMinutes() + '-' + d.getSeconds()
 					+'.xls';

--- a/src/DataTable.vue
+++ b/src/DataTable.vue
@@ -108,7 +108,7 @@
 
 	export default {
 		props: {
-			title: {},
+			title: '',
 			columns: {},
 			rows: {},
 			onClick: {},


### PR DESCRIPTION
Currently the excel export will fail if no title is set.
This PR will allow the export to excel without a given title and instead `Sheet` as a prefix.
