### PR TITLE
Disable fuzzy search

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ perPage       =>    Number of rows per.. page      =>   10 (default)            
 onClick       =>    Func. to execute on click      =>   console.log             // Function, row 1st param
 sortable      =>    Cause column-click to sort     =>   true (default)          // Whether sortable
 searchable    =>    Add fuzzy search functionality =>   true (default)          // Whether searchable
+exactSearch   =>    Disable fuzzy search           =>   true (default)          // Whether only exact matches are returned
 paginate      =>    Add footer next/prev. btns     =>   true (default)          // Whether paginated
 exportable    =>    Add button to export to Excel  =>   true (default)          // Whether exportable
 printable     =>    Add printing functionality     =>   true (default)          // Whether printable

--- a/src/DataTable.vue
+++ b/src/DataTable.vue
@@ -116,6 +116,10 @@
 			perPage: {default: 10},
 			sortable: {default: true},
 			searchable: {default: true},
+			exactSearch: {
+				type: Boolean,
+				default: false
+			},
 			paginate: {default: true},
 			exportable: {default: true},
 			printable: {default: true},
@@ -265,12 +269,17 @@
 						return (x < y ? -1 : (x > y ? 1 : 0)) * (this.sortType === 'desc' ? -1 : 1);
 					})
 
-				if (this.searching && this.searchInput)
-					computedRows = (new Fuse(computedRows, {
-						threshold: 0,
-						distance: 0,
-						keys: this.columns.map(c => c.field)
-					})).search(this.searchInput);
+				if (this.searching && this.searchInput) {
+					const searchConfig = { keys: this.columns.map(c => c.field) }
+
+					if(this.exactSearch){
+						//return only exact matches
+						searchConfig.threshold = 0,
+						searchConfig.distance = 0
+					}
+
+					computedRows = (new Fuse(computedRows, searchConfig)).search(this.searchInput);
+				}
 
                 return computedRows;
 			},

--- a/src/DataTable.vue
+++ b/src/DataTable.vue
@@ -266,6 +266,8 @@
 
 				if (this.searching && this.searchInput)
 					computedRows = (new Fuse(computedRows, {
+						threshold: 0,
+						distance: 0,
 						keys: this.columns.map(c => c.field)
 					})).search(this.searchInput);
 


### PR DESCRIPTION

**Current:**
At the moment searching the table returns all `fuzzy` results. 

**Expected:**
Searching should return only `exact` matches.