### PR TITLE
Handle undefined objects for nested column fields

### DIFF
--- a/src/DataTable.vue
+++ b/src/DataTable.vue
@@ -221,11 +221,14 @@
 			dig: function(obj, selector) {
 				var result = obj;
 				const splitter = selector.split('.');
-				for (let i = 0; i < splitter.length; i++)
-					if (typeof(result) === 'undefined')
+
+				for (let i = 0; i < splitter.length; i++){
+					if (result == undefined)
 						return undefined;
-					else
-						result = result[splitter[i]];
+						
+					result = result[splitter[i]];
+				}
+				
 				return result;
 			},
 


### PR DESCRIPTION
Return undefined if nested column field value is undefinied.

Fixes #7