### PR TITLE
perPage & defaultPerPage

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ rows           =>    Rows.                          =>   [                      
                                                             }
                                                         ]
 perPage        =>    Numbers of rows per page       =>   [10, 20, 30, 40, 50] (default) // Results per page
-defaultperPage =>    Default rows per page          =>   10 (default)            // Default results per page, otherwise it will be the first value of perPage
+defaultPerPage =>    Default rows per page          =>   10 (default)            // Default results per page, otherwise it will be the first value of perPage
 onClick        =>    Func. to execute on click      =>   console.log             // Function, row 1st param
 clickable      =>    Rows are clickable.            =>   true (default)          // Row is passed in the event payload
                     Will fire `row-click` event                                  // See react to click on row (below)

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ And then.. use the component:
 Of course, code above will render garbage. Here are the props it accepts to render some sensible data:
 
 ```
-Prop name     =>    Description                    =>   Example
+Prop name      =>    Description                    =>   Example
 
-title         =>    The title of the datatable     =>   "Todos"                 // Name in top
-columns       =>    Columns.                       =>   [                       // Array of objects
+title          =>    The title of the datatable     =>   "Todos"                 // Name in top
+columns        =>    Columns.                       =>   [                       // Array of objects
                                                             {
                                                                 label: 'Name',  // Column name
                                                                 field: 'name',  // Field name from row
@@ -79,23 +79,24 @@ columns       =>    Columns.                       =>   [                       
                                                                 html: false,    // Escapes output if false.
                                                             }
                                                         ]
-rows          =>    Rows.                          =>   [                       // Array of objects
+rows           =>    Rows.                          =>   [                       // Array of objects
                                                             {
                                                                 name: "test",   // Whatever.
                                                                 ...
                                                             }
                                                         ]
-perPage       =>    Number of rows per.. page      =>   10 (default)            // Results per page
-onClick       =>    Func. to execute on click      =>   console.log             // Function, row 1st param
-clickable     =>    Rows are clickable.            =>   true (default)          // Row is passed in the event payload
+perPage        =>    Numbers of rows per page       =>   [10, 20, 30, 40, 50] (default) // Results per page
+defaultperPage =>    Default rows per page          =>   10 (default) // Default results per page, otherwise it will be the first value of perPage
+onClick        =>    Func. to execute on click      =>   console.log             // Function, row 1st param
+clickable      =>    Rows are clickable.            =>   true (default)          // Row is passed in the event payload
                     Will fire `row-click` event                                 // See react to click on row (below)
-sortable      =>    Cause column-click to sort     =>   true (default)          // Whether sortable
-searchable    =>    Add fuzzy search functionality =>   true (default)          // Whether searchable
-exactSearch   =>    Disable fuzzy search           =>   true (default)          // Whether only exact matches are returned
-paginate      =>    Add footer next/prev. btns     =>   true (default)          // Whether paginated
-exportable    =>    Add button to export to Excel  =>   true (default)          // Whether exportable
-printable     =>    Add printing functionality     =>   true (default)          // Whether printable
-customButtons =>    Custom buttons thingy          =>   [                       // Array of objects
+sortable       =>    Cause column-click to sort     =>   true (default)          // Whether sortable
+searchable     =>    Add fuzzy search functionality =>   true (default)          // Whether searchable
+exactSearch    =>    Disable fuzzy search           =>   true (default)          // Whether only exact matches are returned
+paginate       =>    Add footer next/prev. btns     =>   true (default)          // Whether paginated
+exportable     =>    Add button to export to Excel  =>   true (default)          // Whether exportable
+printable      =>    Add printing functionality     =>   true (default)          // Whether printable
+customButtons  =>    Custom buttons thingy          =>   [                       // Array of objects
                                                             {
                                                                 hide: false,    // Whether to hide the button
                                                                 icon: 'search', // Materialize icon
@@ -126,5 +127,27 @@ var app = new Vue({
 })
 </script>
 ...
+
+```
+
+### Rows per page
+
+You can specify the options of rows per page with the `perPage` prop. The first value will be the default value and the array will be sorted, so you can put whatever number you want. 
+
+```html
+<!-- The default value will be 500 -->
+<datatable :perPage="[100, 10, 25, 50, 500]"></datatable>
+
+```
+
+The options will be rendered as `[10, 20, 50, 100, 500]`
+
+![Rows per page](http://i.imgur.com/kPtppKz.png)
+
+Otherwise, you can specify the default rows per page with the `defaultPerPage` prop.
+
+```html
+<!-- The default value will be 500 -->
+<datatable :perPage="[10, 25, 50, 100, 500]" :defaultPerPage="100"></datatable>
 
 ```

--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ rows           =>    Rows.                          =>   [                      
                                                             }
                                                         ]
 perPage        =>    Numbers of rows per page       =>   [10, 20, 30, 40, 50] (default) // Results per page
-defaultperPage =>    Default rows per page          =>   10 (default) // Default results per page, otherwise it will be the first value of perPage
+defaultperPage =>    Default rows per page          =>   10 (default)            // Default results per page, otherwise it will be the first value of perPage
 onClick        =>    Func. to execute on click      =>   console.log             // Function, row 1st param
 clickable      =>    Rows are clickable.            =>   true (default)          // Row is passed in the event payload
-                    Will fire `row-click` event                                 // See react to click on row (below)
+                    Will fire `row-click` event                                  // See react to click on row (below)
 sortable       =>    Cause column-click to sort     =>   true (default)          // Whether sortable
 searchable     =>    Add fuzzy search functionality =>   true (default)          // Whether searchable
 exactSearch    =>    Disable fuzzy search           =>   true (default)          // Whether only exact matches are returned
@@ -135,7 +135,7 @@ var app = new Vue({
 You can specify the options of rows per page with the `perPage` prop. The first value will be the default value and the array will be sorted, so you can put whatever number you want. 
 
 ```html
-<!-- The default value will be 500 -->
+<!-- The default value will be 100 -->
 <datatable :perPage="[100, 10, 25, 50, 500]"></datatable>
 
 ```
@@ -147,7 +147,7 @@ The options will be rendered as `[10, 20, 50, 100, 500]`
 Otherwise, you can specify the default rows per page with the `defaultPerPage` prop.
 
 ```html
-<!-- The default value will be 500 -->
+<!-- The default value will be 100 -->
 <datatable :perPage="[10, 25, 50, 100, 500]" :defaultPerPage="100"></datatable>
 
 ```

--- a/src/DataTable.vue
+++ b/src/DataTable.vue
@@ -254,13 +254,9 @@
 
 		computed: {
 			perPageOptions: function() {
-				var options = this.perPage;
+				var options = (Array.isArray(this.perPage) && this.perPage) || [10, 20, 30, 40, 50];
 
-				// Init default array if it's not valid
-				if (!Array.isArray(options)) {
-					options = [10, 20, 30, 40, 50];
-				}
-
+				// Force numbers
 				options = options.map(function (v) {
 					return parseInt(v);
 				});

--- a/src/DataTable.vue
+++ b/src/DataTable.vue
@@ -257,17 +257,13 @@
 				var options = (Array.isArray(this.perPage) && this.perPage) || [10, 20, 30, 40, 50];
 
 				// Force numbers
-				options = options.map(function (v) {
-					return parseInt(v);
-				});
+				options = options.map( v => parseInt(v));
 
 				// Set current page to first value
 				this.currentPerPage = options[0];
 
 				// Sort options
-				options.sort(function(a, b) {
-					return a - b;
-				});
+				options.sort((a,b) => a - b);
 
 				// And add "All"
 				options.push(-1);

--- a/src/DataTable.vue
+++ b/src/DataTable.vue
@@ -110,6 +110,7 @@
 			clickable: {default: true},
 			customButtons: {default: () => []},
 			perPage: {default: [10, 20, 30, 40, 50]},
+			defaultPerPage: {default: null},
 			sortable: {default: true},
 			searchable: {default: true},
 			exactSearch: {
@@ -260,6 +261,10 @@
 					options = [10, 20, 30, 40, 50];
 				}
 
+				options = options.map(function (v) {
+					return parseInt(v);
+				});
+
 				// Set current page to first value
 				this.currentPerPage = options[0];
 
@@ -270,6 +275,11 @@
 
 				// And add "All"
 				options.push(-1);
+
+				// If defaultPerPage is provided and it's a valid option, set as current per page
+				if (options.indexOf(this.defaultPerPage) > -1) {
+					this.currentPerPage = parseInt(this.defaultPerPage);
+				}
 
 				return options;
 			},

--- a/src/DataTable.vue
+++ b/src/DataTable.vue
@@ -71,12 +71,9 @@
 				<label>
 					<span>Rows per page:</span>
 					<select class="browser-default" @change="onTableLength">
-						<option value="10">10</option>
-						<option value="20">20</option>
-						<option value="30">30</option>
-						<option value="40">40</option>
-						<option value="50">50</option>
-						<option value="-1">All</option>
+						<option v-for="option in perPageOptions" :value="option" :selected="option === currentPerPage">
+					    {{ option === -1 ? 'All' : option }}
+					  </option>
 					</select>
 				</label>
 			</div>
@@ -112,7 +109,7 @@
 			rows: {},
 			clickable: {default: true},
 			customButtons: {default: () => []},
-			perPage: {default: 10},
+			perPage: {default: [10, 20, 30, 40, 50]},
 			sortable: {default: true},
 			searchable: {default: true},
 			exactSearch: {
@@ -255,6 +252,25 @@
 		},
 
 		computed: {
+			perPageOptions: function() {
+				var options = this.perPage;
+
+				// Init default array if it's not valid
+				if (!Array.isArray(options)) {
+					options = [10, 20, 30, 40, 50];
+				}
+
+				// Set current page to first value
+				this.currentPerPage = options[0];
+
+				// Sort options
+				options.sort();
+
+				// And add "All"
+				options.push(-1);
+
+				return options;
+			},
 			processedRows: function() {
 				var computedRows = this.rows;
 

--- a/src/DataTable.vue
+++ b/src/DataTable.vue
@@ -71,7 +71,7 @@
 				<label>
 					<span>Rows per page:</span>
 					<select class="browser-default" @change="onTableLength">
-						<option v-for="option in perPageOptions" :value="option" :selected="option === currentPerPage">
+						<option v-for="option in perPageOptions" :value="option" :selected="option == currentPerPage">
 					    {{ option === -1 ? 'All' : option }}
 					  </option>
 					</select>
@@ -264,7 +264,9 @@
 				this.currentPerPage = options[0];
 
 				// Sort options
-				options.sort();
+				options.sort(function(a, b) {
+					return a - b;
+				});
 
 				// And add "All"
 				options.push(-1);


### PR DESCRIPTION
Fix #16 

`perPage` will accept an array of values: the one will be the default and then the values are sorted.

Otherwise, you can use `defaultPerPage` to set the default value. (Example in the **README**)