### PR TITLE
Fixing nested path searching issue

### DIFF
--- a/src/DataTable.vue
+++ b/src/DataTable.vue
@@ -314,10 +314,10 @@
 
 					// Enable searching of numbers (non-string)
 					// Temporary fix of https://github.com/krisk/Fuse/issues/144
-				    	searchConfig.getFn = function (obj, path) {
-						if(Number.isInteger(obj[path]))
-						return JSON.stringify(obj[path]);
-					    	return obj[path];
+				    searchConfig.getFn = (obj, path) => {
+						if(Number.isInteger(this.dig(obj, path)))
+							return JSON.stringify(this.dig(obj, path));
+				    	return this.dig(obj, path);
 					}
 
 					if(this.exactSearch){


### PR DESCRIPTION
Searching will not consider fields that are given a nested path (e.g. `attributes.name`), since `getFn` is overridden and looks straight into `obj[path]`, which will give `obj["attributes.name"]` in the mentioned example. The `dig` method should be used to look into nested paths properly.