### PR TITLE
Fix onTableLength assigning currentPerPage as string

### DIFF
--- a/src/DataTable.vue
+++ b/src/DataTable.vue
@@ -152,7 +152,7 @@
 			},
 
 			onTableLength: function(e) {
-				this.currentPerPage = e.target.value;
+				this.currentPerPage = parseInt(e.target.value);
 			},
 
 			sort: function(index) {


### PR DESCRIPTION
When changing the number of rows per page, the `currentPerPage` property gets assigned to a string, and not a number. This results in not viewing all rows when choosing "All", as the identity (triple equality, w/e) operator in the following line will return false:
```js
paginatedRows = paginatedRows.slice((this.currentPage - 1) * this.currentPerPage, this.currentPerPage === -1 ? paginatedRows.length + 1 : this.currentPage * this.currentPerPage);
```