### PR TITLE
Make Datatable Responsive

### DIFF
--- a/src/DataTable.vue
+++ b/src/DataTable.vue
@@ -561,6 +561,7 @@
 <style scoped>
 	div.material-table {
 		padding: 0;
+		overflow-x: scroll;
 	}
 
 	tr.clickable {


### PR DESCRIPTION
The data-table before this commit wasn't responsive,
and when the number of columns increase or the
screen reduces, data are lost.

This commit fixes that issue,
so when the screen reduces a scrollbar is introduced,
this stops the issue of losing visuals of the data in the table.