### PR TITLE
Automatically reset the current page to 1 when rows change

### DIFF
--- a/src/DataTable.vue
+++ b/src/DataTable.vue
@@ -467,6 +467,12 @@
 				if (this.searching && this.serverSearch && this.serverSearchFunc)
 					this.serverSearchFunc(newSearchInput);
 			},
+
+			rows(newRows, oldRows) {
+				// If the number of rows change, reset the currentPage to 1
+				if(newRows !== oldRows)
+					this.currentPage = 1;
+			},
 		},
 
 		computed: {


### PR DESCRIPTION
**Current situation:**

When the data on the table changes, for example, by appling an external filter, the currentPage variable is not reseted to 1. If you are in a page different than the first one and the filtered data produces less rows than the necesary for that page, the table becomes blank and the datatable info at is wrong, for example, it will say "10-3 of 3"

\
**Fix:**

The watcher resets the currentPage to 1 each time the rows change